### PR TITLE
Update prmLogoAfter.html

### DIFF
--- a/html/prmLogoAfter.html
+++ b/html/prmLogoAfter.html
@@ -1,5 +1,5 @@
 <div class="product-logo product-logo-local" layout="row" layout-align="start center" layout-fill id="banner" tabindex="0" role="banner">
-  <md-button aria-label="{{::('nui.header.LogoAlt' | translate)}}" ng-click="$ctrl.navigation.navigateToHomePage()">
+  <md-button aria-label="{{('nui.header.LogoAlt' | translate)}}" ng-click="$ctrl.navigation.navigateToHomePage()">
     <img ng-src="{{$ctrl.getIconLink()}}" alt="{{::('nui.header.LogoAlt' | translate)}}"/>
   </md-button>
 </div>


### PR DESCRIPTION
Correct error, without  '::' this part work. Its a error in the original documentation. 
At the Moment in your Primo webside it looks `<img ng-src="custom/NUI/img/library-logo.png" alt="nui.header.LogoAlt" src="custom/NUI/img/library-logo.png">` so the 'alt' is not ok. After the correction you will have the text you can change in search in Primo BO AdvancedConfiguration / All Code Tables / search for nui.header